### PR TITLE
feat(offset): allow skipping the shadow-caret calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ const frameOffset = getOffset(frame);
   off.left += frameOffset.left;
   off.top += frameOffset.top;
 ```
+
+### shadow caret
+When getting the offset, in certain cases a "shadow caret" is temporarily created and destroyed to facilitate calculations.
+If one does not wish to mutate the DOM in this way, one can include the `noShadowCaret` option in the offset:
+
+```javascript
+import { offset } from 'caret-pos';
+
+offset(el, {noShadowCaret: true});
+```
+
+Note that doing this might make the offset calculation less accurate in some edge cases.

--- a/src/caret.spec.js
+++ b/src/caret.spec.js
@@ -1,4 +1,4 @@
-import { position } from './main';
+import { position, offset } from './main';
 
 describe('caret-pos', () => {
   let element = null;
@@ -115,4 +115,59 @@ describe('caret-pos', () => {
     });
   });
 });
+
+describe('caret-offset', () => {
+  let element = null;
+  let editor;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    element.id = 'wrapper';
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.parentNode.removeChild(element);
+  });
+
+  describe('Editable', () => {
+    let contentEditable;
+
+    beforeEach(() => {
+      spyOn(document, 'createTextNode').and.callThrough();
+      contentEditable = ''
+        + '<div id="editor" contentEditable="true">'
+        + 'Hello '
+        + '<span id="test">World</span>'
+        + '! '
+        + '<div><br></div>'
+        + '<div>'
+        + '<ul>'
+        + '<li>Testing 1</li>'
+        + '<li>Testin 2</li>'
+        + '</ul>'
+        + '<div>--</div>'
+        + '</div>'
+        + '<div><br></div>'
+        + '</div>';
+
+      element.innerHTML = contentEditable;
+      editor = document.getElementById('editor');
+    });
+
+    it('should correctly get the caret offset', () => {
+      position(editor, 3);
+      const off = offset(editor);
+      expect(off.height).toBe(19);
+      expect(off.left).toBe(37);
+      expect(off.top).toBe(8);
+    });
+
+    it('should respect noShadowCaret', () => {
+      position(editor, 0);
+      offset(editor, {noShadowCaret: true});
+      expect(document.createTextNode).not.toHaveBeenCalled();
+    });
+  })
+})
 

--- a/src/editable.js
+++ b/src/editable.js
@@ -79,7 +79,7 @@ const createEditableCaret = (element, ctx) => {
       clonedRange.detach();
     }
 
-    if (!offset || (offset && offset.height === 0)) {
+    if ((!offset || (offset && offset.height === 0)) && !ctx.noShadowCaret) {
       const clonedRange = range.cloneRange();
       const shadowCaret = ctx.document.createTextNode('|');
       clonedRange.insertNode(shadowCaret);

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,18 +18,20 @@ export const isContentEditable = (element) => !!(
  * @return {object} window and document
  */
 export const getContext = (settings = {}) => {
-  const { iframe } = settings;
+  const { iframe, noShadowCaret } = settings;
   if (iframe) {
     return {
       iframe,
       window: iframe.contentWindow,
       document: iframe.contentDocument || iframe.contentWindow.document,
+      noShadowCaret,
     };
   }
 
   return {
     window,
     document,
+    noShadowCaret,
   };
 };
 


### PR DESCRIPTION
Hey @deshiknaves - continuing our conversation on https://github.com/deshiknaves/caret-pos/issues/1

I also added a basic test for `offset` (in addition to the noShadowCaret test) because I coudln't find any.