### PR TITLE
Allow getting offset from custom position in element

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ offset(el, { noShadowCaret: true });
 ```
 
 Note that doing this might make the offset calculation less accurate in some edge cases.
+
+### custom position
+Passing the `customPos` option allows specifying a custom cursor position in the element when getting the offset.
+This will not change the position, but calculate the offset from the custom position rather than the current one.
+This works for both contentEditable and textarea.
+
+```javascript
+import { offset } from 'caret-pos';
+
+offset(el, { customPos: 2 });
+```

--- a/src/caret.spec.js
+++ b/src/caret.spec.js
@@ -33,6 +33,14 @@ describe('caret-pos', () => {
 
       expect(pos.pos).toBe(15);
     });
+
+    it('should correctly get the caret offset with a custom position', () => {
+      position(editor, 3);
+      const off = offset(editor, {customPos: 2});
+      expect(off.height).toBe(19);
+      expect(off.left).toBe(22);
+      expect(off.top).toBe(12);
+    });
   });
 
   describe('Editable', () => {
@@ -167,6 +175,14 @@ describe('caret-offset', () => {
       position(editor, 0);
       offset(editor, {noShadowCaret: true});
       expect(document.createTextNode).not.toHaveBeenCalled();
+    });
+
+    it('should correctly get the caret offset with a custom position', () => {
+      position(editor, 3);
+      const off = offset(editor, {customPos: 2});
+      expect(off.height).toBe(19);
+      expect(off.left).toBe(31);
+      expect(off.top).toBe(8);
     });
   })
 })

--- a/src/editable.js
+++ b/src/editable.js
@@ -64,12 +64,15 @@ const createEditableCaret = (element, ctx) => {
       return offset;
     }
 
+    const hasCustomPos = ctx.customPos || ctx.customPos === 0;
+
     // endContainer in Firefox would be the element at the start of
     // the line
-    if (range.endOffset - 1 > 0 && range.endContainer !== element) {
+    if ((range.endOffset - 1 > 0 && range.endContainer !== element) || hasCustomPos) {
       const clonedRange = range.cloneRange();
-      clonedRange.setStart(range.endContainer, range.endOffset - 1);
-      clonedRange.setEnd(range.endContainer, range.endOffset);
+      const fixedPosition = hasCustomPos ? ctx.customPos : range.endOffset;
+      clonedRange.setStart(range.endContainer, fixedPosition - 1 < 0 ? 0 : fixedPosition - 1);
+      clonedRange.setEnd(range.endContainer, fixedPosition);
       const rect = clonedRange.getBoundingClientRect();
       offset = {
         height: rect.height,

--- a/src/input.js
+++ b/src/input.js
@@ -66,6 +66,10 @@ const createInputCaret = (element, ctx) => {
       return value;
     };
 
+    if (ctx.customPos || ctx.customPos === 0) {
+      pos = ctx.customPos;
+    }
+
     const position = pos === undefined ? getPos() : pos;
     const startRange = element.value.slice(0, position);
     const endRange = element.value.slice(position);

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,13 +18,14 @@ export const isContentEditable = (element) => !!(
  * @return {object} window and document
  */
 export const getContext = (settings = {}) => {
-  const { iframe, noShadowCaret } = settings;
+  const { customPos, iframe, noShadowCaret } = settings;
   if (iframe) {
     return {
       iframe,
       window: iframe.contentWindow,
       document: iframe.contentDocument || iframe.contentWindow.document,
       noShadowCaret,
+      customPos,
     };
   }
 
@@ -32,6 +33,7 @@ export const getContext = (settings = {}) => {
     window,
     document,
     noShadowCaret,
+    customPos,
   };
 };
 


### PR DESCRIPTION
Hi @deshiknaves - I hope you'd be up for this additional feature.
So, previously the lib had this feature only for textArea, and the API was IMO a little confusing. I added this feature for both textArea and contentEditable with the same API (passing `{customPos: <pos>}`).

Let me know if you'd like me to make any changes.