### PR TITLE
fix(firefox): do not convert space characters to nbsp

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -60,9 +60,6 @@ const createInputCaret = (element, ctx) => {
     const format = (val) => {
       let value = val.replace(/<|>|`|"|&/g, '?')
         .replace(/\r\n|\r|\n/g,'<br/>');
-      if (/firefox/i.test(navigator.userAgent)) {
-        value = value.replace(/\s/g, '&nbsp;');
-      }
       return value;
     };
 


### PR DESCRIPTION
So, I'll admit that I'm not sure why this was needed in the first place (everything seems to work without it). With it though, multiline textareas with word-wrapped lines are not reported correctly. wdyt?