### PR TITLE
Make isContentEditable support other DOM's

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,8 +6,9 @@
  * @return {bool} If it is content editable
  */
 export const isContentEditable = (element) => !!(
-  element.contentEditable &&
-  element.contentEditable === 'true'
+  element.contentEditable ?
+  element.contentEditable === 'true' :
+  element.getAttribute("contenteditable") === "true"
 );
 
 /**


### PR DESCRIPTION
If the element has no `contentEditable` property - use `element.getAttribute` instead