### PR TITLE
Support other browser APIs for contentEditable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added typings
 - Removed `yarn` in preference to `npm`
 - Updated vulnerable packages
+- `isContentEditable` will support other browser APIs where `element.contentEditable` can only be accessed by `element.getAttribute('contentEditable')`.
 
 # Version 1.2.1 - 2018-09-04
 - Removed conversion from `\s` to `&nbsp;` for Firefox. It's not needed.

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,8 +6,9 @@
  * @return {bool} If it is content editable
  */
 export const isContentEditable = (element) => !!(
-  element.contentEditable &&
-  element.contentEditable === 'true'
+  element.contentEditable ?
+    element.contentEditable === 'true' :
+    element.getAttribute('contenteditable') === 'true'
 );
 
 /**


### PR DESCRIPTION
- `isContentEditable` will support other browser APIs where `element.contentEditable` can only be accessed by `element.getAttribute('contentEditable')`.