### PR TITLE
Fix index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export type Pos = { left: number, top: number, height: number, pos: number }
  * Gets or sets the position. Pass value to set, omit to get.
  */
 export declare function position(element: Element, settings?: CaretPositionSettings): Pos;
-export declare function position(element: Element, value?: number, settings?: CaretPositionSettings): Pos;
+export declare function position(element: Element, value?: number, settings?: CaretPositionSettings): Element;
 
 export type Offset = { left: number, top: number, height: number }
 


### PR DESCRIPTION
`position` function inside the code returns `Element` but inside the
declaration file the overload for setting the position of caret declares
`Pos` as the value returned by the set overload of the function